### PR TITLE
Bump com.github.johnrengelman.shadow from 7.1.1 to 7.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     `java-library`
     `maven-publish`
-    id("com.github.johnrengelman.shadow") version "7.1.1"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
     id("org.sonarqube") version "3.3"
     checkstyle
     jacoco


### PR DESCRIPTION
Bumps com.github.johnrengelman.shadow from 7.1.1 to 7.1.2.

---
updated-dependencies:
- dependency-name: com.github.johnrengelman.shadow
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>